### PR TITLE
Add new services

### DIFF
--- a/data/government-service/government-service.tsv
+++ b/data/government-service/government-service.tsv
@@ -120,3 +120,9 @@ government-service	hostname	government-organisation	start-date	end-date
 1165	gender-pay-gap	OT506		
 1166	submit-flood-coastal-erosion-funding-proposal	EA199		
 1167	trade-tariff	D25		
+1167	ethnicity-facts-figures	D2	2017-09-20	
+1168	supplier-cyber-protection	D17	2017-07-18	
+1169	check-payment-practices	D1198	2017-10-05	
+1170	publish-payment-practices	D1198	2017-10-05	
+1171	schools-financial-benchmarking	D6	2017-06-22	
+1172	help-with-prison-visits	D18	2017-06-22	


### PR DESCRIPTION
From the custodian

> I have the following additions to the government service register:
>
> hostname: ethnicity-facts-figures
> organisation: D2
> start date: 20/9/2017
>
> hostname: supplier-cyber-protection
> organisation: D17
> start date: 18/7/2017
> 
> hostname: check-payment-practices
> organisation: D1198
> start date: 5/10/2017
>
> hostname: publish-payment-practices
> organisation: D1198
> start date: 5/10/2017
>
> hostname: schools-financial-benchmarking
> organisation: D6
> start date: 22/6/17
>
> hostname: help-with-prison-visits
> organisation: D18
> start date: 20/6/17"

All services confirmed online except ethnicity-facts-figures, which doesn't work
today but did last week.

New entries are at the bottom of the tsv file